### PR TITLE
Support file path passed in as a command line argument

### DIFF
--- a/src/cctar/io.rs
+++ b/src/cctar/io.rs
@@ -1,0 +1,29 @@
+use std::{fs::File, io::{stdin, Error, Read}};
+
+pub fn read_stdin() -> Result<Vec<u8>, Error>{
+    read_source(stdin())
+}
+
+pub fn read_file(path: &str) -> Result<Vec<u8>, Error>{
+    let f = File::open(path)?;
+    read_source(f)
+}
+
+fn read_source<T: Read>(mut file: T) -> Result<Vec<u8>, Error>{
+    let mut contents: Vec<u8> = Vec::new();
+    let mut buffer = [0; 1024];
+    loop {
+        let read_result = file.read(&mut buffer);
+        match read_result {
+            Ok(n) => {
+                if n == 0 {
+                    break;
+                }
+                contents.extend(&buffer[0 .. n]);
+            },
+            Err(e) => { return Err(e);}
+        }
+        
+    }
+    Ok(contents)
+}

--- a/src/cctar/mod.rs
+++ b/src/cctar/mod.rs
@@ -1,3 +1,4 @@
 pub mod tar;
 pub mod types;
 pub mod constants;
+pub mod io;

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -3,7 +3,15 @@ pub enum TarMode {
     List
 }
 
+#[derive(PartialEq)]
+pub enum InputSource {
+    Stdin,
+    File
+}
+
 pub struct Config {
     pub mode: TarMode,
-    pub block_size: usize
+    pub block_size: usize,
+    pub input_src: InputSource,
+    pub input_file: String
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,34 @@
 use std::env;
 
-use config::types::{Config, TarMode};
+use config::types::{Config, InputSource, TarMode};
 use cctar::{constants, tar::run_tar};
 
 pub mod cctar;
 pub mod config;
 
-#[allow(clippy::single_match)]
 fn main() {
     let mut cfg = Config{
         mode: TarMode::Create,
-        block_size: constants::DEFAULT_BLOCK_SIZE_BYTES
+        block_size: constants::DEFAULT_BLOCK_SIZE_BYTES,
+        input_src: InputSource::Stdin,
+        input_file: "".to_string(),
     };
     let args: Vec<String> = env::args().collect();
-    for arg in args {
-        let arg_value = arg.as_str();
+    let mut arg_counter: usize = 0;
+    while arg_counter < args.len() {
+        let arg_value = args[arg_counter].as_str();
         match arg_value {
             "-t" => {
                 cfg.mode = TarMode::List;
             }
+            "-f" => {
+                cfg.input_src = InputSource::File;
+                arg_counter += 1;
+                cfg.input_file = args[arg_counter].as_str().to_string();
+            }
             _ => {}
         }
+        arg_counter += 1;
     }
     run_tar(&cfg);
 }

--- a/test/test_cc_tar.bats
+++ b/test/test_cc_tar.bats
@@ -10,7 +10,7 @@ setup() {
     mkdir -p "${TEST_EXPECTATIONS_DIR}"
 }
 
-@test "is able to list the files in a tar archive with prefixed files" {
+@test "is able to list the files in a tar archive from stdin with prefixed files" {
     create_sample_single_file_block_tarball 4 "example"
 
     # build expectation
@@ -25,7 +25,7 @@ setup() {
     diff "${TEST_RESULTS_DIR}/results.txt" "${TEST_EXPECTATIONS_DIR}/expect.txt" >&3
 }
 
-@test "is able to list the files in a tar archive having files without a prefix" {
+@test "is able to list the files in a tar archive from stdin having files without a prefix" {
     create_sample_single_file_block_tarball 4
 
     # build expectation
@@ -35,6 +35,21 @@ setup() {
     done
 
     cat "${BATS_TEST_TMPDIR}/test-archive.tar" | ${BINARY} -t | sort | tee "${TEST_RESULTS_DIR}/results.txt" >&3
+
+    diff "${TEST_RESULTS_DIR}/results.txt" "${TEST_EXPECTATIONS_DIR}/expect.txt" >&3
+}
+
+@test "is able to list the files in the specified tar archive with prefixed files" {
+    create_sample_single_file_block_tarball 4 "example"
+
+    # build expectation
+    echo "./" >> "${TEST_EXPECTATIONS_DIR}/expect.txt"
+    echo "./example/" >> "${TEST_EXPECTATIONS_DIR}/expect.txt"
+    for ((i=0; i < 4; i++)); do
+        echo "./example/file${i}.txt" >> "${TEST_EXPECTATIONS_DIR}/expect.txt"
+    done
+
+    ${BINARY} -t -f "${BATS_TEST_TMPDIR}/test-archive.tar" | sort | tee "${TEST_RESULTS_DIR}/results.txt" >&3
 
     diff "${TEST_RESULTS_DIR}/results.txt" "${TEST_EXPECTATIONS_DIR}/expect.txt" >&3
 }


### PR DESCRIPTION
This commit adds support for the -f flag in order to take in a file as a command line argument.

The file from the path will be read into memory and processed exactly as it would if the file was read from STDIN.