### PR TITLE
Add support for benchmarking the application against GNU tar.

### DIFF
--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -33,3 +33,11 @@ jobs:
       - name: functional tests
         run: |
           make functional-test
+  code_bench:
+    runs-on: ubuntu-latest
+    needs: code_test
+    steps:
+      - uses: actions/checkout@v4
+      - name: benchmark application
+        run: |
+          make benchmark

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,16 @@ build-release:
 PHONY: functional-test
 functional-test: build-release
 	$(BATS_BINARY) test/test_cc_tar.bats
+
+bench-data-1G.bin:
+	dd if=/dev/random of=bench-data-1G.bin bs=1M count=1000
+
+bench-data-2G.bin:
+	dd if=/dev/random of=bench-data-2G.bin bs=2M count=1000
+
+bench-data-archive.tar: bench-data-1G.bin bench-data-2G.bin
+	tar -cf bench-data-archive.tar bench-data-1G.bin bench-data-2G.bin
+
+PHONY: benchmark
+benchmark: build-release bench-data-archive.tar
+	/bin/sh test/benchmark.sh

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ echo "file 4 contents" > file4.txt
 tar -cf test-archive.tar file1.txt file2.txt file3.txt file4.txt
 
 cat ./test-archive.tar | ./target/release/cc-tar-rs -t
+OR
+./target/release/cc-tar-rs -t -f ./test-archive.tar
 ```
 
 ## Contributing

--- a/test/benchmark.sh
+++ b/test/benchmark.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+PROJECT_ROOT="$( git rev-parse --show-toplevel )"
+BINARY="${PROJECT_ROOT}/target/release/cc-tar-rs"
+
+echo "comparing archive listing performance"
+echo "GNU tar"
+/usr/bin/time --verbose tar -t -f ./bench-data-archive.tar
+echo ""
+echo "cc-tar-rs"
+/usr/bin/time --verbose ${BINARY} -t -f ./bench-data-archive.tar


### PR DESCRIPTION
To check if the implementation is optimal, there is a need to benchmark cc-tar-rs against GNU tar.
This PR uses /usr/bin/time in order to do so.